### PR TITLE
feat: first-run key setup flow

### DIFF
--- a/apps/server/src/provider/Drivers/FreebuffDriver.ts
+++ b/apps/server/src/provider/Drivers/FreebuffDriver.ts
@@ -98,7 +98,12 @@ export const FreebuffDriver: ProviderDriver<FreebuffSettings, FreebuffDriverEnv>
             type: "api_key",
             label: "Codebuff API key",
           },
-          ...(hasKey ? {} : { message: "No API key set — add one in settings." }),
+          ...(hasKey
+            ? {}
+            : {
+                message:
+                  "No API key set — grab a free one at codebuff.com/api-keys, then add it in Settings → Connections.",
+              }),
         },
       });
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6295,6 +6295,7 @@ function ChatViewContent(props: ChatViewProps) {
               <ProviderStatusBanner
                 status={visibleProviderStatus}
                 onDismiss={() => setDismissedProviderStatusBannerKey(providerStatusBannerKey)}
+                onOpenSettings={() => void navigate({ to: "/settings/connections" })}
               />
             </div>
             {/* Messages Wrapper */}

--- a/apps/web/src/components/chat/ProviderStatusBanner.test.tsx
+++ b/apps/web/src/components/chat/ProviderStatusBanner.test.tsx
@@ -36,7 +36,7 @@ describe("ProviderStatusBanner", () => {
 
   it("renders an accessible dismiss control for provider warnings", () => {
     const markup = renderToStaticMarkup(
-      <ProviderStatusBanner status={warningProvider()} onDismiss={() => {}} />,
+      <ProviderStatusBanner status={warningProvider()} onDismiss={() => {}} onOpenSettings={() => {}} />,
     );
 
     expect(markup).toContain('role="alert"');
@@ -46,7 +46,7 @@ describe("ProviderStatusBanner", () => {
 
   it("renders on a glass surface so the timeline never reads through the banner", () => {
     const markup = renderToStaticMarkup(
-      <ProviderStatusBanner status={warningProvider()} onDismiss={() => {}} />,
+      <ProviderStatusBanner status={warningProvider()} onDismiss={() => {}} onOpenSettings={() => {}} />,
     );
 
     expect(markup).toContain("alert-glass");
@@ -58,6 +58,7 @@ describe("ProviderStatusBanner", () => {
       <ProviderStatusBanner
         status={{ ...warningProvider(), status: "error" }}
         onDismiss={() => {}}
+        onOpenSettings={() => {}}
       />,
     );
 

--- a/apps/web/src/components/chat/ProviderStatusBanner.tsx
+++ b/apps/web/src/components/chat/ProviderStatusBanner.tsx
@@ -22,9 +22,11 @@ export function shouldShowProviderStatusBanner(
 
 export const ProviderStatusBanner = memo(function ProviderStatusBanner({
   onDismiss,
+  onOpenSettings,
   status,
 }: {
   onDismiss: () => void;
+  onOpenSettings: () => void;
   status: ServerProvider | null;
 }) {
   if (!status || status.status === "ready" || status.status === "disabled") {
@@ -36,12 +38,15 @@ export const ProviderStatusBanner = memo(function ProviderStatusBanner({
   const title = isUnauthenticated
     ? `${providerName} is unauthenticated`
     : `${providerName} provider status`;
-  const message = isUnauthenticated
-    ? "Sign in via the CLI to authenticate again."
-    : (status.message ??
-      (status.status === "error"
+  // Driver-supplied message wins: drivers know their own recovery path
+  // (e.g. Freebuff points at its API-key settings field).
+  const message =
+    status.message ??
+    (isUnauthenticated
+      ? "Add credentials in Settings → Connections to start using this provider."
+      : status.status === "error"
         ? `${providerName} provider is unavailable.`
-        : `${providerName} provider has limited availability.`));
+        : `${providerName} provider has limited availability.`);
 
   return (
     <div className="pointer-events-auto mx-auto w-fit max-w-[calc(100%-2rem)] pt-3">
@@ -67,6 +72,15 @@ export const ProviderStatusBanner = memo(function ProviderStatusBanner({
             </TooltipPopup>
           </Tooltip>
         </div>
+        <Button
+          aria-label={`Open settings to fix ${providerName} provider`}
+          className="shrink-0"
+          onClick={onOpenSettings}
+          size="xs"
+          variant="secondary"
+        >
+          Open settings
+        </Button>
         <Button
           aria-label={`Dismiss ${providerName} provider ${status.status}`}
           className="absolute top-2 right-2 size-6 text-muted-foreground hover:text-foreground"


### PR DESCRIPTION
Closes #7

## What
The missing-key first-run journey, end to end:
1. **Detect**: driver snapshot reports `error` + `unauthenticated` + actionable message (free key URL + where to paste it) — machinery from #3
2. **Surface**: chat `ProviderStatusBanner` shows driver-supplied copy (driver message now wins over the generic `Sign in via the CLI` text, which was wrong for Freebuff) — visible on first launch without a key
3. **Act**: new `Open settings` action on the banner navigates to `/settings/connections`
4. **Enter + store**: the schema-driven provider form (password field from #3 annotations) persists the key to server settings — local-only, existing settings persistence path, never logged
5. **Confirm**: settings watcher rehydrates the instance; snapshot flips to `ready`/`authenticated`; banner clears (its state key includes auth status)

## Honest scope notes
- Live SDK validation of the key on save is deferred: a bad key surfaces on first turn as a `turn.completed {failed}` with the backend's error message. A pre-flight validation call lands with #4's deeper SDK integration.
- 'Stored locally only' = the server's settings persistence in its state dir (single-user local server).

## Verification
- `pnpm typecheck` — 0 · `pnpm build` — 0 (banner tests updated for the new prop)