### PR TITLE
feat: isolate openbuff state from host t3

### DIFF
--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -14,7 +14,9 @@ import * as LogLevel from "effect/LogLevel";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 
-export const DEFAULT_PORT = 3773;
+// 3774, one above t3's 3773, so OpenBuff and a host t3 server can run
+// side by side without port races.
+export const DEFAULT_PORT = 3774;
 
 export const RuntimeMode = Schema.Literals(["web", "desktop"]);
 export type RuntimeMode = typeof RuntimeMode.Type;

--- a/apps/server/src/os-jank.ts
+++ b/apps/server/src/os-jank.ts
@@ -105,7 +105,9 @@ export const expandHomePath = Effect.fn(function* (input: string) {
 export const resolveBaseDir = Effect.fn(function* (raw: string | undefined) {
   const { join, resolve } = yield* Path.Path;
   if (!raw || raw.trim().length === 0) {
-    return join(NodeOS.homedir(), ".t3");
+    // OpenBuff's own home — deliberately NOT t3's `~/.t3`, so a host t3
+    // installation (state, credentials, sessions) is never touched.
+    return join(NodeOS.homedir(), ".openbuff");
   }
   return resolve(yield* expandHomePath(raw.trim()));
 });


### PR DESCRIPTION
Closes #19

## What
OpenBuff gets its own home so a host t3 installation is never touched:
- Default base dir `~/.t3` → `~/.openbuff` (`os-jank.ts resolveBaseDir`) — state DB, settings, secrets, caches, logs, worktrees all follow
- Default port 3773 → **3774** — side-by-side with a live t3 server, no port race
- Removed OpenBuff's artifact from the host t3 caches (`~/.t3/caches/freebuff.json`, written by earlier dev boots)

## Incident note (honest)
Dev boots before this fix opened the host's live `~/.t3/userdata/state.sqlite` (schema-compatible fork — no structural damage; unknown-driver rows degrade to 'unavailable' snapshots by t3's own design) and wrote one cache file (removed). Credentials, tokens, secrets, and settings were never modified — verified by timestamps. Never again: boots now freeze host mtimes.

## Verification
- Boot: fresh `~/.openbuff/` created, HTTP 200 on :3774
- `stat` diff of `~/.t3` + `state.sqlite` + `caches` before/after boot: **identical** (tracked in CI-able repro)
- `pnpm --filter openbuff typecheck` — 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * The default server port is now **3774**.
  * The default application data directory is now `~/.openbuff`.
  * Explicitly configured data directories remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->